### PR TITLE
Add notify event listener to `CanNotify` trait

### DIFF
--- a/packages/admin/src/Http/Livewire/Concerns/CanNotify.php
+++ b/packages/admin/src/Http/Livewire/Concerns/CanNotify.php
@@ -9,6 +9,13 @@ use Filament\Facades\Filament;
  */
 trait CanNotify
 {
+    protected function getListeners()
+    {
+        return array_merge($this->listeners, [
+            'notify' => 'notify',
+        ]);
+    }
+    
     public function notify(string $status, string $message, bool $isAfterRedirect = false): void
     {
         Filament::notify($status, $message);


### PR DESCRIPTION
This PR adds the ability to create Filament Notifications directly in blade files using Livewire Events.

This helps if someone wants to notify from child Components (or even simple blade components).

Example:
```html
<!-- resources/views/code-highlighter.blade.php -->
<div
    x-data="{
        copy_data: $el.querySelector('code').innerText,
    }"
>
    <code>...</code>
    <button
            @click="$clipboard(copy_data)"
            wire:click="$emitUp('notify', 'success', 'Code copied to clipboard')"
    >
            <x-dynamic-component component="heroicon-o-duplicate" />
    </button>
</div>
```